### PR TITLE
Before you had to specify an address for the vault server. Now it def…

### DIFF
--- a/bin/vaultconf
+++ b/bin/vaultconf
@@ -18,6 +18,10 @@ class App
     config = options['c']
     configure_kubernetes = !options['nokube']
 
+    if !server
+      server = ENV['VAULT_ADDR']
+    end
+
     if !user || !password
       debug 'No username or password specified, retrieving details from config file'
       user, password = Vaultconf::Vaultconf.read_login_from_file
@@ -69,7 +73,7 @@ class App
   arg :action, "Action that you want to perform. Allowable values are \"users\" or \"policies\""
   on("-u VAL", "--user", "Specifies the user to use to create the new config in vault")
   on("-p VAL", "--password", "Specifies the password for the user who is creating the config in vault")
-  on("-a VAL", "--address", "URL for the vault server")
+  on("-a VAL", "--address", "URL for the vault server. If no address is specified VAULT_ADDR environment variable will be used")
   on("--nokube", "Configure only Vault, don't touch kubernetes")
   on("-c VAL", "--config", "Specifies either the directory containing vault policies to be added, or the file containing users to be added")
   on("-v", "--verbose", "Verbose logging")


### PR DESCRIPTION
…aults to VAULT_ADDR if no address is specified
